### PR TITLE
Add missing API key instructions

### DIFF
--- a/fushion/README.md
+++ b/fushion/README.md
@@ -8,14 +8,20 @@ UI from **talking-bubble-verse-main-3**.
 
 ## Running the project
 
-1. Start the FastAPI backend
+1. Create a `.env` file with your OpenAI API key
+
+   ```bash
+   echo "OPENAI_API_KEY=your-key" > .env
+   ```
+
+2. Start the FastAPI backend
 
    ```bash
    cd fushion
    uvicorn main:app --reload
    ```
 
-2. In another terminal start the Vite dev server
+3. In another terminal start the Vite dev server
 
    ```bash
    npm install

--- a/fushion/main.py
+++ b/fushion/main.py
@@ -34,6 +34,12 @@ load_dotenv(find_dotenv())
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 SECRET         = os.getenv("APP_SECRET", "change-me")
 
+if not OPENAI_API_KEY:
+    raise RuntimeError(
+        "OPENAI_API_KEY environment variable is missing. \n"
+        "Set it in a `.env` file or export it before running the server."
+    )
+
 VECTOR_STORE1_ID = "vs_6822d7e1761881918b5ee78d3d689562"
 VECTOR_STORE2_ID = "vs_6822d7e5e79881919418a3bea0987f89"
 


### PR DESCRIPTION
## Summary
- instruct to create `.env` with `OPENAI_API_KEY`
- error if the API key is missing at backend startup

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685be9ca4da88326ba3a3f6a681492f8