### PR TITLE
Fix streaming buffer handling

### DIFF
--- a/fushion/src/hooks/useStreamingChat.tsx
+++ b/fushion/src/hooks/useStreamingChat.tsx
@@ -70,13 +70,15 @@ export const useStreamingChat = (
       const decoder = new TextDecoder();
       let accumulatedContent = '';
       const steps: StreamStep[] = [];
+      let buffer = '';
 
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
 
-        const chunk = decoder.decode(value, { stream: true });
-        const lines = chunk.split('\n');
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
 
         for (const line of lines) {
           if (line.startsWith('[STEP]')) {
@@ -111,6 +113,10 @@ export const useStreamingChat = (
             }));
           }
         }
+      }
+
+      if (buffer.trim() && buffer.trim() !== '[DONE]') {
+        accumulatedContent += buffer.trim();
       }
 
       setStreamingState(prev => ({


### PR DESCRIPTION
## Summary
- retain partial lines while streaming chat output

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685bed8b83588326a0646feb87ddca01